### PR TITLE
Update benchmarking for consistent timing

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -1,29 +1,58 @@
-for n in {1..20}
+ITERATIONS=20
+
+cargo build --release
+
+# Used for klee output as many folders are created normally
+tmpkleedir=$(mktemp -d 2>/dev/null)
+
+# Stores the hyperfine output for timings
+mkdir benchmark_output
+
+echo "Running benchmark on safe functions with Wombat-SymX"
+for n in $(seq $ITERATIONS)
 do
     python3 generate_test_seq_br.py rust $n safe
+    rustc --emit=llvm-bc test_seq_br_safe_$n.rs
     echo /usr/bin/time cargo run -- test_seq_br_safe_$n.rs test
-    time ( cargo run -- test_seq_br_safe_$n.rs test > /dev/null 2>&1 ) 2>&1
+    hyperfine --warmup 2 --export-csv benchmark_output/wombat_safe_$n.csv "target/release/wombat_symx -b test_seq_br_safe_$n.rs test > /dev/null 2>&1"
+    rm test_seq_br_safe_$n.*
 done
 
-for n in {1..20}
+echo
+echo
+echo "Running benchmark on unsafe functions with Wombat-SymX"
+for n in $(seq $ITERATIONS)
 do
     python3 generate_test_seq_br.py rust $n unsafe
+    rustc --emit=llvm-bc test_seq_br_unsafe_$n.rs
     echo /usr/bin/time cargo run -- test_seq_br_unsafe_$n.rs test
-    time ( cargo run -- test_seq_br_unsafe_$n.rs test > /dev/null 2>&1 ) 2>&1
+    hyperfine --warmup 2 --export-csv benchmark_output/wombat_unsafe_$n.csv "target/release/wombat_symx -b test_seq_br_unsafe_$n.rs test > /dev/null 2>&1"
+    rm test_seq_br_unsafe_$n.*
 done
 
-for n in {1..20}
+echo
+echo
+echo "Running benchmark on safe functions with KLEE"
+for n in $(seq $ITERATIONS)
 do
     python3 generate_test_seq_br.py c $n safe
     clang -I "/opt/homebrew/Cellar/klee/2.3_4/include/klee" -emit-llvm -c -g -O0 -Xclang -disable-O0-optnone test_seq_br_safe_$n.c
     echo klee test_seq_br_safe_$n.bc
-    time ( klee test_seq_br_safe_$n.bc > /dev/null 2>&1 ) 2>&1
+    hyperfine --warmup 2 --prepare "rm -rf $tmpkleedir/klee_safe_$n" --cleanup "rm -rf $tmpkleedir/klee_safe_$n" --export-csv benchmark_output/klee_safe_$n.csv "klee --output-dir $tmpkleedir/klee_safe_$n test_seq_br_safe_$n.bc > /dev/null 2>&1"
+    rm test_seq_br_safe_$n.*
 done
 
-for n in {1..20}
+echo
+echo
+echo "Running benchmark on unsafe functions with KLEE"
+for n in $(seq $ITERATIONS)
 do
     python3 generate_test_seq_br.py c $n unsafe
     clang -I "/opt/homebrew/Cellar/klee/2.3_4/include/klee" -emit-llvm -c -g -O0 -Xclang -disable-O0-optnone test_seq_br_unsafe_$n.c
     echo klee test_seq_br_unsafe_$n.bc
-    time ( klee test_seq_br_unsafe_$n.bc > /dev/null 2>&1 ) 2>&1
+    hyperfine --warmup 2 --prepare "rm -rf $tmpkleedir/klee_unsafe_$n" --cleanup "rm -rf $tmpkleedir/klee_unsafe_$n" --export-csv benchmark_output/klee_unsafe_$n.csv "klee --output-dir $tmpkleedir/klee_unsafe_$n test_seq_br_unsafe_$n.bc > /dev/null 2>&1"
+    rm test_seq_br_unsafe_$n.*
 done
+
+echo "Performing cleanup of extra files:"
+rm -rvf $tmpkleedir

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,10 @@ struct Args {
     /// Set function to perform symbolic execution on
     #[clap()]
     function_name: String,
+
+    /// Enable benchmark mode which disables compilation of test files
+    #[clap(short, long)]
+    benchmark_mode: bool,
 }
 
 fn main() {
@@ -35,6 +39,5 @@ fn main() {
 
     let file_name = String::from(&features.file_name);
     let function_name = String::from(&features.function_name);
-
-    symbolic_execution(&file_name, &function_name);
+    symbolic_execution(&file_name, &function_name, features.benchmark_mode);
 }

--- a/src/symbolic_execution.rs
+++ b/src/symbolic_execution.rs
@@ -196,12 +196,6 @@ pub fn symbolic_execution(file_name: &String, function_name: &String, is_benchma
                 warn!("{} is not a supported parameter type!", var_type);
             }
         }
-        let mut source_file_content = fs::read_to_string(file_name).unwrap();
-        source_file_content = source_file_content.replace("fn main", "fn _main");
-        source_file_content = format!("{}\nfn main() {{{}(", source_file_content, function_name);
-        for argument_value in &argument_values {
-            source_file_content = format!("{}{},", source_file_content, argument_value);
-        }
 
         let mut source_file_content = fs::read_to_string(file_name).unwrap();
         if !function_name.eq(&String::from("main")) {

--- a/src/symbolic_execution.rs
+++ b/src/symbolic_execution.rs
@@ -91,11 +91,7 @@ pub fn symbolic_execution(file_name: &String, function_name: &String, is_benchma
             .expect("Failed to generate bytecode file!");
     }
 
-    let _temp_bc_file_dropper = if !is_benchmark_mode {
-        Some(FileDropper {
-            file_name: &bytecode_file_name,
-        })
-    } else { None };
+    let _temp_bc_file_dropper = if !is_benchmark_mode { Some(FileDropper { file_name: &bytecode_file_name }) } else { None };
 
     let module_result = get_inkwell_module(&context, &bytecode_file_name);
     module_result.as_ref()?;
@@ -199,11 +195,11 @@ pub fn symbolic_execution(file_name: &String, function_name: &String, is_benchma
             } else {
                 warn!("{} is not a supported parameter type!", var_type);
             }
-        };
+        }
         let mut source_file_content = fs::read_to_string(file_name).unwrap();
         source_file_content = source_file_content.replace("fn main", "fn _main");
         source_file_content = format!("{}\nfn main() {{{}(", source_file_content, function_name);
-        for argument_value in argument_values {
+        for argument_value in &argument_values {
             source_file_content = format!("{}{},", source_file_content, argument_value);
         }
 
@@ -212,7 +208,7 @@ pub fn symbolic_execution(file_name: &String, function_name: &String, is_benchma
             // Inject custom main function as entry point for test program to generate stack trace
             source_file_content = source_file_content.replace("fn main", "fn _main");
             source_file_content = format!("{}\nfn main() {{{}(", source_file_content, function_name);
-            for argument_value in argument_values {
+            for argument_value in &argument_values {
                 source_file_content = format!("{}{},", source_file_content, argument_value);
             }
             source_file_content = format!("{});}}", source_file_content);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,7 +41,7 @@ pub fn test(test_name: &str, function_name: &str, source_code: &str, expected_sa
 
     fs::write(&source_file_name, format!("{}\n{}", source_code.replace("            ", ""), main)).expect("Failed to write temp test file!");
 
-    let actual_safe = wombat_symx::symbolic_execution::symbolic_execution(&source_file_name, &String::from(function_name));
+    let actual_safe = wombat_symx::symbolic_execution::symbolic_execution(&source_file_name, &String::from(function_name), false);
 
     assert!(expected_safe == actual_safe.unwrap());
 }


### PR DESCRIPTION
Updates the benchmark script to use `hyperfine` (command for getting execution time for programs with mean/std dev). To avoid large numbers of directories getting created, the script will create a temp directory for Klee.

To avoid extra compilations, an extra option is provided for wombat-symx (`-b`/`--benchmark-mode`) which does not run the compilation to LLVM bytecode for the test file (instead, relies on the user to create this prior).

For the case of unsafe functions in benchmark mode, the program will still create a new test file to trigger and capture the panic caused by the unsafe arguments.