### PR TITLE
Sort function arg names array for unsafe func output

### DIFF
--- a/src/symbolic_execution.rs
+++ b/src/symbolic_execution.rs
@@ -170,7 +170,15 @@ pub fn symbolic_execution(file_name: &String, function_name: &String) -> Option<
         // Exhibit a pathological input if the function is unsafe
         // Supports signed int types and booleans
         let model = solver.get_model().unwrap();
-        debug!("\n{:?}", model);
+
+        // Difficult to manually extract variables in model. Instead, parse and clean model output
+        let model_str = format!("{:?}", model);
+        let mut model_output_tokens: Vec<String> = model_str.split('\n').map(|s| s.to_string()).collect();
+        model_output_tokens.remove(0);
+        model_output_tokens.sort();
+        let cleaned_model_output = model_output_tokens.join("\n");
+        debug!("{}", cleaned_model_output);
+
         println!("\nUnsafe values:");
         let mut argument_values = Vec::<String>::new();
         for (arg_name, z3_name, var_type) in func_arg_names {

--- a/src/symbolic_execution.rs
+++ b/src/symbolic_execution.rs
@@ -174,7 +174,6 @@ pub fn symbolic_execution(file_name: &String, function_name: &String) -> Option<
         // Difficult to manually extract variables in model. Instead, parse and clean model output
         let model_str = format!("{:?}", model);
         let mut model_output_tokens: Vec<String> = model_str.split('\n').map(|s| s.to_string()).collect();
-        model_output_tokens.remove(0);
         model_output_tokens.sort();
         let cleaned_model_output = model_output_tokens.join("\n");
         debug!("{}", cleaned_model_output);

--- a/src/utils/function_utils.rs
+++ b/src/utils/function_utils.rs
@@ -73,7 +73,8 @@ pub fn get_all_function_argument_names<'a>(module: &'a InkwellModule, solver: &'
     let mut next_function = module.get_first_function();
     while let Some(current_function) = next_function {
         let current_full_function_name = get_function_name(&current_function.as_global_value().as_pointer_value());
-        let function_argument_names = get_function_argument_names(current_function, solver, namespace);
+        let mut function_argument_names = get_function_argument_names(current_function, solver, namespace);
+        function_argument_names.sort_by(|(arg_name_a, _z3_a, _bte_a), (arg_name_b, _z3_b, _bte_b)| arg_name_a.cmp(arg_name_b));
         all_func_arg_names.insert(current_full_function_name, function_argument_names);
         next_function = current_function.get_next_function();
     }

--- a/src/utils/function_utils.rs
+++ b/src/utils/function_utils.rs
@@ -73,8 +73,7 @@ pub fn get_all_function_argument_names<'a>(module: &'a InkwellModule, solver: &'
     let mut next_function = module.get_first_function();
     while let Some(current_function) = next_function {
         let current_full_function_name = get_function_name(&current_function.as_global_value().as_pointer_value());
-        let mut function_argument_names = get_function_argument_names(current_function, solver, namespace);
-        function_argument_names.sort_by(|(arg_name_a, _z3_a, _bte_a), (arg_name_b, _z3_b, _bte_b)| arg_name_a.cmp(arg_name_b));
+        let function_argument_names = get_function_argument_names(current_function, solver, namespace);
         all_func_arg_names.insert(current_full_function_name, function_argument_names);
         next_function = current_function.get_next_function();
     }


### PR DESCRIPTION
Small PR to sort the function argument name vector by arg name.

Example:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/31224968/224195622-0a50f8a2-60d6-4ecd-8fe1-25c0de2a29f4.png">


Output:
<img width="195" alt="image" src="https://user-images.githubusercontent.com/31224968/224195599-444f9337-3f93-467a-a842-26c96c6ba77f.png">
